### PR TITLE
Bug fix `event.request.headers.origin` may be missing

### DIFF
--- a/plugins/mod_bosh.lua
+++ b/plugins/mod_bosh.lua
@@ -118,7 +118,7 @@ local function set_cross_domain_headers(response)
 end
 
 function handle_OPTIONS(event)
-	if cross_domain and event.request.headers.origin then
+	if cross_domain then
 		set_cross_domain_headers(event.response);
 	end
 	return "";


### PR DESCRIPTION
In certain browser configurations the `Origin` header may be missing in which case `event.request.headers.origin` will resolve to `nil` and the CORS headers won't be sent. Thus the best solution is to remove the `Origin` header check and rely solely open the `cross_origin` flag.